### PR TITLE
Enabling support of Unregulated motors on BrickPi 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for BrickPi3 for EV3Dev Debian Stretch
 - Add support for BrickPi+ for EV3Dev Debian Stretch
+- Add support for Unregulated motors on BrickPi 3
 
 ## 2.4.16 2018-11-15
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ plugins {
     id 'maven-publish'
 }
 
-version = '2.5.1-SNAPSHOT'
+version = '2.5.1'
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ plugins {
     id 'maven-publish'
 }
 
-version = '2.5.0'
+version = '2.5.1-SNAPSHOT'
 
 repositories {
     jcenter()

--- a/src/main/java/ev3dev/actuators/lego/motors/BasicMotor.java
+++ b/src/main/java/ev3dev/actuators/lego/motors/BasicMotor.java
@@ -9,6 +9,9 @@ import lejos.utility.Delay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /** 
  * Abstraction for basic motors operations.
  *
@@ -31,8 +34,12 @@ public abstract class BasicMotor extends EV3DevMotorDevice implements DCMotor {
      */
 	public BasicMotor(final Port motorPort) {
 
-		if(!CURRENT_PLATFORM.equals(EV3DevPlatform.EV3BRICK)){
-			throw new RuntimeException("This device is not supported in this platform");
+		Set<EV3DevPlatform> supportedUnregulatedMotors = new HashSet<>();
+		supportedUnregulatedMotors.add(EV3DevPlatform.EV3BRICK);
+		supportedUnregulatedMotors.add(EV3DevPlatform.BRICKPI3);
+
+		if(!supportedUnregulatedMotors.contains(CURRENT_PLATFORM)) {
+			throw new RuntimeException("This device is not supported in the platform: " + CURRENT_PLATFORM);
 		}
 
 		final EV3DevPlatforms ev3DevPlatforms = EV3DevPlatforms.getInstance();

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 Implementation-Title: EV3Dev-lang-java
-Implementation-Version: 2.5.0
+Implementation-Version: 2.5.1-SNAPSHOT
 Implementation-Vendor: Juan Antonio Breña Moral

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 Implementation-Title: EV3Dev-lang-java
-Implementation-Version: 2.5.1-SNAPSHOT
+Implementation-Version: 2.5.1
 Implementation-Vendor: Juan Antonio Breña Moral


### PR DESCRIPTION
Enabled support of Unregulated motors.

Tested on EV3 & BrickPi3 to avoid any possible side effect.

Approve the change, later I will change the version to merge in master.