### PR TITLE
Improved Sysfs robustness

### DIFF
--- a/src/main/java/ev3dev/hardware/EV3DevDevice.java
+++ b/src/main/java/ev3dev/hardware/EV3DevDevice.java
@@ -113,10 +113,7 @@ public abstract class EV3DevDevice {
      * @param value value
      */
     protected void setStringAttribute(final String attribute, final String value){
-        final boolean result = Sysfs.writeString(this.PATH_DEVICE + "/" +  attribute, value);
-        if(!result){
-            throw new RuntimeException("Operation not executed: " + this.PATH_DEVICE + "/" +  attribute + " with value " + value);
-        }
+        Sysfs.writeString(this.PATH_DEVICE + "/" +  attribute, value);
     }
 
     /**

--- a/src/main/java/ev3dev/utils/Sysfs.java
+++ b/src/main/java/ev3dev/utils/Sysfs.java
@@ -36,17 +36,12 @@ public class Sysfs {
 			log.trace("echo " + value + " > " + filePath);
 		try {
 			final File file = new File(filePath);
-			if(file.canWrite()) {
 				//TODO Review if it possible to improve
 				PrintWriter out = new PrintWriter(file);
 				out.println(value);
 				out.flush();
 				out.close();
 			//TODO Review
-			}else {
-				log.error("File: '{}' without write permissions.", filePath);
-				return false;
-			}
 		} catch (IOException e) {
             log.error(e.getLocalizedMessage(), e);
 			return false;


### PR DESCRIPTION
This PR builds on top of https://github.com/ev3dev-lang-java/ev3dev-lang-java/pull/650 and adds some small refactorings to Sysfs:

 - #650 is integrated. Together with this, the writeString() now manually encodes the string to bytes and writes it using FileOutputStream. This should ensure the best performance.
 - readString() is a bit tweaked to use exceptions in a better way.
 - getElements() is checking for null value of a result.
 - write* method do not return a boolean anymore. This is because I think exceptions already convey that an error occured. The only usage of this boolean was to throw an exception.
 - Slf4j formatting functions are used, so it is not necessary to check if tracing is enabled. Slf4j already checks if the level is enabled before the format is processed.

To keep this clean, a separate PR will follow to resolve #651.