### PR TITLE
LED enum and documentation

### DIFF
--- a/src/main/java/ev3dev/actuators/ev3/EV3Led.java
+++ b/src/main/java/ev3dev/actuators/ev3/EV3Led.java
@@ -7,6 +7,11 @@ import lejos.hardware.LED;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This class provides methods for interacting with the LEDs on the EV3Brick.
+ * <p>
+ * <i>Only EV3Bricks are supported.</i>
+ */
 public class EV3Led extends EV3DevDevice implements LED {
 
     /**
@@ -92,13 +97,17 @@ public class EV3Led extends EV3DevDevice implements LED {
     //TODO Add Enums for patterns
 
     /**
-     * 0: turn off button lights
-     * 1/2/3: static light green/red/yellow
-     * 4/5/6: normal blinking light green/red/yellow
-     * 7/8/9: fast blinking light green/red/yellow
-     * >9: same as 9.
+     * Sets the pattern of light to be shown with this LED.
      *
-     * @param pattern
+     * @param pattern the pattern to show with this LED.
+     *                <p>
+     *                0: Turns off the LED light;
+     *                <p>
+     *                1/2/3: Static green/red/yellow light;
+     *                <p>
+     *                4/5/6: Normal blinking green/red/yellow light, <i>not implemented</i>;
+     *                <p>
+     *                7/8/9: Fast blinking green/red/yellow light, <i>not implemented</i>.
      */
     @Override
     public void setPattern(final int pattern) {
@@ -120,6 +129,11 @@ public class EV3Led extends EV3DevDevice implements LED {
         }
     }
 
+    /**
+     * Returns the direction of the LED associated with this object.
+     *
+     * @return the direction of the LED, either {@link Direction#LEFT} or {@link Direction#RIGHT}.
+     */
     public Direction getDirection() {
         return direction;
     }

--- a/src/main/java/ev3dev/actuators/ev3/EV3Led.java
+++ b/src/main/java/ev3dev/actuators/ev3/EV3Led.java
@@ -9,37 +9,84 @@ import org.slf4j.LoggerFactory;
 
 public class EV3Led extends EV3DevDevice implements LED {
 
+    /**
+     * Directions of the LED.
+     */
+    public enum Direction {
+        LEFT,
+        RIGHT
+    }
+
     private static final Logger log = LoggerFactory.getLogger(EV3Led.class);
 
     public static final int LEFT = 0;
     public static final int RIGHT = 1;
 
-    final private int direction;
+    private final Direction direction;
 
-    private final String LED_LEFT_RED;
-    private final String LED_LEFT_GREEN;
-    private final String LED_RIGHT_RED;
-    private final String LED_RIGHT_GREEN;
+    private final String LED_RED;
+    private final String LED_GREEN;
 
+    /**
+     * Create an EV3LED object associated with the LED of the specified direction.
+     *
+     * @param direction the direction of the LED, either {@link Direction#LEFT} or {@link Direction#RIGHT}.
+     * @throws RuntimeException if LED feature is not supported on the current platform.
+     */
+    public EV3Led(final Direction direction) {
+        checkPlatform();
+
+        if (direction == null) {
+            log.error("You are not specifying any button.");
+            throw new IllegalArgumentException("You are not specifying any button.");
+        }
+
+        this.direction = direction;
+
+        if (direction == Direction.LEFT) {
+            LED_RED = ev3DevProperties.getProperty("ev3.led.left.red");
+            LED_GREEN = ev3DevProperties.getProperty("ev3.led.left.green");
+        } else {
+            LED_RED = ev3DevProperties.getProperty("ev3.led.right.red");
+            LED_GREEN = ev3DevProperties.getProperty("ev3.led.right.green");
+        }
+    }
+
+    /**
+     * Creates an EV3LED object associated with the LED of the specified direction.
+     *
+     * @param button the direction of the LED, should be either {@link #LEFT} or {@link #RIGHT}.
+     * @throws RuntimeException if LED feature is not supported on the current platform.
+     * @deprecated Use {@link #EV3Led(Direction)} instead.
+     */
     public EV3Led(final int button) {
+        checkPlatform();
 
-        LED_LEFT_RED = ev3DevProperties.getProperty("ev3.led.left.red");
-        LED_LEFT_GREEN = ev3DevProperties.getProperty("ev3.led.left.green");
-        LED_RIGHT_RED = ev3DevProperties.getProperty("ev3.led.right.red");
-        LED_RIGHT_GREEN = ev3DevProperties.getProperty("ev3.led.right.green");
+        if (button == LEFT) {
+            LED_RED = ev3DevProperties.getProperty("ev3.led.left.red");
+            LED_GREEN = ev3DevProperties.getProperty("ev3.led.left.green");
+            direction = Direction.LEFT;
+        } else if (button == RIGHT) {
+            LED_RED = ev3DevProperties.getProperty("ev3.led.right.red");
+            LED_GREEN = ev3DevProperties.getProperty("ev3.led.right.green");
+            direction = Direction.RIGHT;
+        } else {
+            log.error("You are not specifying any button.");
+            throw new IllegalArgumentException("You are not specifying any button.");
+        }
 
+    }
+
+    /**
+     * Checks if the current platform support this feature.
+     *
+     * @throws RuntimeException if this feature is not supported on the current platform.
+     */
+    private void checkPlatform() {
         if (!CURRENT_PLATFORM.equals(EV3DevPlatform.EV3BRICK)) {
             log.error("This actuator is specific of: {}", EV3DevPlatform.EV3BRICK);
             throw new RuntimeException("This actuator is specific of: " + EV3DevPlatform.EV3BRICK);
         }
-
-        //TODO Use ENUM
-        if (button != 0 && button != 1) {
-            log.error("You are not specifying any button.");
-            throw new RuntimeException("You are not specifying any button.");
-        }
-
-        direction = button == 0 ? LEFT : RIGHT;
     }
 
     //TODO Add Enums for patterns
@@ -57,40 +104,23 @@ public class EV3Led extends EV3DevDevice implements LED {
     public void setPattern(final int pattern) {
         //Off
         if (pattern == 0) {
-            if (direction == LEFT) {
-                Sysfs.writeInteger(LED_LEFT_RED, 0);
-                Sysfs.writeInteger(LED_LEFT_GREEN, 0);
-            } else {
-                Sysfs.writeInteger(LED_RIGHT_RED, 0);
-                Sysfs.writeInteger(LED_RIGHT_GREEN, 0);
-            }
+            Sysfs.writeInteger(LED_RED, 0);
+            Sysfs.writeInteger(LED_GREEN, 0);
         } else if (pattern == 1) {
-            if (direction == LEFT) {
-                Sysfs.writeInteger(LED_LEFT_RED, 0);
-                Sysfs.writeInteger(LED_LEFT_GREEN, 255);
-            } else {
-                Sysfs.writeInteger(LED_RIGHT_RED, 0);
-                Sysfs.writeInteger(LED_RIGHT_GREEN, 255);
-            }
+            Sysfs.writeInteger(LED_RED, 0);
+            Sysfs.writeInteger(LED_GREEN, 255);
         } else if (pattern == 2) {
-            if (direction == LEFT) {
-                Sysfs.writeInteger(LED_LEFT_RED, 255);
-                Sysfs.writeInteger(LED_LEFT_GREEN, 0);
-            } else {
-                Sysfs.writeInteger(LED_RIGHT_RED, 255);
-                Sysfs.writeInteger(LED_RIGHT_GREEN, 0);
-            }
+            Sysfs.writeInteger(LED_RED, 255);
+            Sysfs.writeInteger(LED_GREEN, 0);
         } else if (pattern == 3) {
-            if (direction == LEFT) {
-                Sysfs.writeInteger(LED_LEFT_RED, 255);
-                Sysfs.writeInteger(LED_LEFT_GREEN, 255);
-            } else {
-                Sysfs.writeInteger(LED_RIGHT_RED, 255);
-                Sysfs.writeInteger(LED_RIGHT_GREEN, 255);
-            }
+            Sysfs.writeInteger(LED_RED, 255);
+            Sysfs.writeInteger(LED_GREEN, 255);
         } else if (pattern > 3) {
             log.debug("This feature is not implemented");
         }
     }
 
+    public Direction getDirection() {
+        return direction;
+    }
 }

--- a/src/main/java/ev3dev/actuators/ev3/EV3Led.java
+++ b/src/main/java/ev3dev/actuators/ev3/EV3Led.java
@@ -9,88 +9,88 @@ import org.slf4j.LoggerFactory;
 
 public class EV3Led extends EV3DevDevice implements LED {
 
-	private static final Logger log = LoggerFactory.getLogger(EV3Led.class);
+    private static final Logger log = LoggerFactory.getLogger(EV3Led.class);
 
-	public static final int LEFT = 0;
+    public static final int LEFT = 0;
     public static final int RIGHT = 1;
 
     final private int direction;
 
-	private final String LED_LEFT_RED;
-	private final String LED_LEFT_GREEN;
-	private final String LED_RIGHT_RED;
-	private final String LED_RIGHT_GREEN;
+    private final String LED_LEFT_RED;
+    private final String LED_LEFT_GREEN;
+    private final String LED_RIGHT_RED;
+    private final String LED_RIGHT_GREEN;
 
-	public EV3Led(final int button) {
+    public EV3Led(final int button) {
 
-		LED_LEFT_RED = ev3DevProperties.getProperty("ev3.led.left.red");
-		LED_LEFT_GREEN = ev3DevProperties.getProperty("ev3.led.left.green");
-		LED_RIGHT_RED = ev3DevProperties.getProperty("ev3.led.right.red");
-		LED_RIGHT_GREEN = ev3DevProperties.getProperty("ev3.led.right.green");
+        LED_LEFT_RED = ev3DevProperties.getProperty("ev3.led.left.red");
+        LED_LEFT_GREEN = ev3DevProperties.getProperty("ev3.led.left.green");
+        LED_RIGHT_RED = ev3DevProperties.getProperty("ev3.led.right.red");
+        LED_RIGHT_GREEN = ev3DevProperties.getProperty("ev3.led.right.green");
 
-		if(!CURRENT_PLATFORM.equals(EV3DevPlatform.EV3BRICK)){
+        if (!CURRENT_PLATFORM.equals(EV3DevPlatform.EV3BRICK)) {
             log.error("This actuator is specific of: {}", EV3DevPlatform.EV3BRICK);
             throw new RuntimeException("This actuator is specific of: " + EV3DevPlatform.EV3BRICK);
         }
 
         //TODO Use ENUM
-		if (button != 0 && button != 1){
+        if (button != 0 && button != 1) {
             log.error("You are not specifying any button.");
-			throw new RuntimeException("You are not specifying any button.");
-		}
+            throw new RuntimeException("You are not specifying any button.");
+        }
 
-		direction = button == 0 ? LEFT : RIGHT;
-	}
+        direction = button == 0 ? LEFT : RIGHT;
+    }
 
-	//TODO Add Enums for patterns
-	/**
-	 *
-	 * 0: turn off button lights
-	 * 1/2/3: static light green/red/yellow
-	 * 4/5/6: normal blinking light green/red/yellow
-	 * 7/8/9: fast blinking light green/red/yellow
-	 * >9: same as 9.
-	 *
-	 * @param pattern
-	 */
-	@Override
-	public void setPattern(final int pattern) {
-		//Off
-		if (pattern == 0) {
-			if (direction == LEFT){
-				Sysfs.writeInteger(LED_LEFT_RED, 0);
-				Sysfs.writeInteger(LED_LEFT_GREEN, 0);
-			} else {
-				Sysfs.writeInteger(LED_RIGHT_RED, 0);
-				Sysfs.writeInteger(LED_RIGHT_GREEN, 0);
-			}
-		} else if (pattern == 1) {
-			if (direction == LEFT) {
-				Sysfs.writeInteger(LED_LEFT_RED, 0);
-				Sysfs.writeInteger(LED_LEFT_GREEN, 255);
-			} else {
-				Sysfs.writeInteger(LED_RIGHT_RED, 0);
-				Sysfs.writeInteger(LED_RIGHT_GREEN, 255);
-			}
-		} else if (pattern == 2) {
-			if (direction == LEFT){
-				Sysfs.writeInteger(LED_LEFT_RED, 255);
-				Sysfs.writeInteger(LED_LEFT_GREEN, 0);
-			} else {
-				Sysfs.writeInteger(LED_RIGHT_RED, 255);
-				Sysfs.writeInteger(LED_RIGHT_GREEN, 0);
-			}
-		} else if (pattern == 3) {
-			if (direction == LEFT) {
-				Sysfs.writeInteger(LED_LEFT_RED, 255);
-				Sysfs.writeInteger(LED_LEFT_GREEN, 255);
-			} else {
-				Sysfs.writeInteger(LED_RIGHT_RED, 255);
-				Sysfs.writeInteger(LED_RIGHT_GREEN, 255);
-			}
-		} else if (pattern > 3) {
-			log.debug("This feature is not implemented");
-		}
-	}
+    //TODO Add Enums for patterns
+
+    /**
+     * 0: turn off button lights
+     * 1/2/3: static light green/red/yellow
+     * 4/5/6: normal blinking light green/red/yellow
+     * 7/8/9: fast blinking light green/red/yellow
+     * >9: same as 9.
+     *
+     * @param pattern
+     */
+    @Override
+    public void setPattern(final int pattern) {
+        //Off
+        if (pattern == 0) {
+            if (direction == LEFT) {
+                Sysfs.writeInteger(LED_LEFT_RED, 0);
+                Sysfs.writeInteger(LED_LEFT_GREEN, 0);
+            } else {
+                Sysfs.writeInteger(LED_RIGHT_RED, 0);
+                Sysfs.writeInteger(LED_RIGHT_GREEN, 0);
+            }
+        } else if (pattern == 1) {
+            if (direction == LEFT) {
+                Sysfs.writeInteger(LED_LEFT_RED, 0);
+                Sysfs.writeInteger(LED_LEFT_GREEN, 255);
+            } else {
+                Sysfs.writeInteger(LED_RIGHT_RED, 0);
+                Sysfs.writeInteger(LED_RIGHT_GREEN, 255);
+            }
+        } else if (pattern == 2) {
+            if (direction == LEFT) {
+                Sysfs.writeInteger(LED_LEFT_RED, 255);
+                Sysfs.writeInteger(LED_LEFT_GREEN, 0);
+            } else {
+                Sysfs.writeInteger(LED_RIGHT_RED, 255);
+                Sysfs.writeInteger(LED_RIGHT_GREEN, 0);
+            }
+        } else if (pattern == 3) {
+            if (direction == LEFT) {
+                Sysfs.writeInteger(LED_LEFT_RED, 255);
+                Sysfs.writeInteger(LED_LEFT_GREEN, 255);
+            } else {
+                Sysfs.writeInteger(LED_RIGHT_RED, 255);
+                Sysfs.writeInteger(LED_RIGHT_GREEN, 255);
+            }
+        } else if (pattern > 3) {
+            log.debug("This feature is not implemented");
+        }
+    }
 
 }

--- a/src/test/java/ev3dev/actuators/ev3/EV3LedTest.java
+++ b/src/test/java/ev3dev/actuators/ev3/EV3LedTest.java
@@ -5,10 +5,7 @@ import ev3dev.hardware.EV3DevPlatform;
 import fake_ev3dev.ev3dev.actuators.FakeLed;
 import fake_ev3dev.ev3dev.sensors.FakeBattery;
 import lejos.hardware.LED;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
@@ -118,6 +115,19 @@ public class EV3LedTest {
         led.setPattern(2);
         led.setPattern(3);
         led.setPattern(4);
+    }
+
+    @Test
+    public void getDirectionTest() throws Exception {
+
+        final FakeBattery fakeBattery = new FakeBattery(EV3DevPlatform.EV3BRICK);
+        final FakeLed fakeLed = new FakeLed(EV3DevPlatform.EV3BRICK);
+
+        EV3Led led = new EV3Led(EV3Led.RIGHT);
+        Assert.assertEquals(EV3Led.Direction.RIGHT, led.getDirection());
+
+        led = new EV3Led(EV3Led.Direction.RIGHT);
+        Assert.assertEquals(EV3Led.Direction.RIGHT, led.getDirection());
     }
 
 }

--- a/src/test/java/ev3dev/actuators/ev3/EV3LedTest.java
+++ b/src/test/java/ev3dev/actuators/ev3/EV3LedTest.java
@@ -39,6 +39,7 @@ public class EV3LedTest {
         final FakeBattery fakeBattery = new FakeBattery(EV3DevPlatform.EV3BRICK);
 
         LED led = new EV3Led(EV3Led.LEFT);
+        led = new EV3Led(EV3Led.Direction.LEFT);
     }
 
     @Test
@@ -47,6 +48,7 @@ public class EV3LedTest {
         final FakeBattery fakeBattery = new FakeBattery(EV3DevPlatform.EV3BRICK);
 
         LED led = new EV3Led(EV3Led.RIGHT);
+        led = new EV3Led(EV3Led.Direction.RIGHT);
     }
 
     @Ignore("Review how to reset a Static classic in JUnit")
@@ -67,8 +69,17 @@ public class EV3LedTest {
 
         final FakeBattery fakeBattery = new FakeBattery(EV3DevPlatform.EV3BRICK);
 
-        //TODO Use a Enum in the constructor
         LED led = new EV3Led(2);
+    }
+
+    @Test
+    public void badDirectionTest() throws Exception {
+
+        thrown.expect(IllegalArgumentException.class);
+
+        final FakeBattery fakeBattery = new FakeBattery(EV3DevPlatform.EV3BRICK);
+
+        LED led = new EV3Led(null);
     }
 
     @Test
@@ -77,8 +88,13 @@ public class EV3LedTest {
         final FakeBattery fakeBattery = new FakeBattery(EV3DevPlatform.EV3BRICK);
         final FakeLed fakeLed = new FakeLed(EV3DevPlatform.EV3BRICK);
 
-        //TODO Use a Enum in the constructor
         LED led = new EV3Led(EV3Led.LEFT);
+        led.setPattern(1);
+        led.setPattern(2);
+        led.setPattern(3);
+        led.setPattern(4);
+
+        led = new EV3Led(EV3Led.Direction.LEFT);
         led.setPattern(1);
         led.setPattern(2);
         led.setPattern(3);
@@ -91,8 +107,13 @@ public class EV3LedTest {
         final FakeBattery fakeBattery = new FakeBattery(EV3DevPlatform.EV3BRICK);
         final FakeLed fakeLed = new FakeLed(EV3DevPlatform.EV3BRICK);
 
-        //TODO Use a Enum in the constructor
         LED led = new EV3Led(EV3Led.RIGHT);
+        led.setPattern(1);
+        led.setPattern(2);
+        led.setPattern(3);
+        led.setPattern(4);
+
+        led = new EV3Led(EV3Led.Direction.RIGHT);
         led.setPattern(1);
         led.setPattern(2);
         led.setPattern(3);


### PR DESCRIPTION
Hello, 

I have made some changes to the `EV3Led` class. Here are the changes that have been made:

- Change the constructor to use enum to indicate direction instead of integers. The old constructor is kept but documented as deprecated.
- Remove some unnecessary declaration and if checks to clean the code up a little bit.
- Complete the documentation for the class and methods.
- Modify the `EV3LedTest` class so that it can test the new methods.

I'm also planning on adding more features to it such as setting the RG colour (since there's no blue) of the light and getting the current status, and probably the blinking lights mentioned in the documentation but not implemented yet.

Regards,

Keisun