### PR TITLE
Upgrade plugin to 1.6.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id "jacoco"
     id 'checkstyle'
     id 'maven-publish'
-    id 'com.github.ev3dev-lang-java.gradle-plugin' version '1.6.5'
+    id 'com.github.ev3dev-lang-java.gradle-plugin' version '1.6.8'
     id "net.ossindex.audit" version "0.4.5-beta"
     id "com.github.johnrengelman.shadow" version "4.0.3"
 }
@@ -34,16 +34,16 @@ dependencies {
     compileOnly("org.projectlombok:lombok:1.16.20")
     testCompileOnly("org.projectlombok:lombok:1.16.20")
 
-    compile("org.slf4j:slf4j-api:1.7.25")
-    compile("com.github.ev3dev-lang-java:lejos-commons:0.7.3")
-    compile("net.java.dev.jna:jna:4.5.2")
+    implementation("org.slf4j:slf4j-api:1.7.25")
+    implementation("com.github.ev3dev-lang-java:lejos-commons:0.7.3")
+    implementation("net.java.dev.jna:jna:4.5.2")
 
-    testCompile("ch.qos.logback:logback-classic:1.2.3")
+    testImplementation("ch.qos.logback:logback-classic:1.2.3")
 
-    testCompile("commons-io:commons-io:2.5")
+    testImplementation("commons-io:commons-io:2.5")
 
-    testCompile("junit:junit:4.12")
-    testCompile("org.hamcrest:hamcrest-all:1.3")
+    testImplementation("junit:junit:4.12")
+    testImplementation("org.hamcrest:hamcrest-all:1.3")
 }
 
 compileJava.options.encoding = 'UTF-8'


### PR DESCRIPTION
This depends on https://github.com/ev3dev-lang-java/gradle-plugin/pull/11 and release of 1.6.8.

Fixes-Bugs: ev3dev-lang-java/gradle-plugin#5, ev3dev-lang-java/gradle-plugin#10
Fixes-PRs: ev3dev-lang-java/gradle-plugin#11, ev3dev-lang-java/gradle-plugin#8, ev3dev-lang-java/gradle-plugin#6
Tag-Diff: https://github.com/ev3dev-lang-java/gradle-plugin/compare/1.6.5...1.6.8