### PR TITLE
Configure speed_sp before executing rotate() and rotateTo()

### DIFF
--- a/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
+++ b/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
@@ -265,6 +265,7 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
      */
     public void rotate(int angle, boolean immediateReturn) {
 		this.setIntegerAttribute(POSITION_SP, angle);
+    	this.setSpeed(this.speed);
 		this.setStringAttribute(COMMAND, RUN_TO_REL_POS);
 		
 		if (!immediateReturn) {
@@ -289,6 +290,7 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
 
     public void rotateTo(int limitAngle, boolean immediateReturn) {
     	this.setIntegerAttribute(POSITION_SP, limitAngle);
+    	this.setSpeed(this.speed);
     	this.setStringAttribute(COMMAND, RUN_TO_ABS_POS);
 		
 		if (!immediateReturn) {


### PR DESCRIPTION
This is connected to issue #663. When motors are after reset, they have their speed_sp set to zero. When a run command is invoked in this state, the motor (and the library while in blocking mode) freeze, because the kernel regulator considers the motor to be stalled.