### PR TITLE
Trigger stop action when calling flt() and similar functions

### DIFF
--- a/docs/adr/adr-lejos-api-changes.md
+++ b/docs/adr/adr-lejos-api-changes.md
@@ -33,3 +33,5 @@ that break previously established promises:
   wait for a new value in ev3dev. This means that IR sensor function
   reading multiple commands will read only one, otherwise it will
   throw an exception.
+
+* Motor synchronization is not yet implemented.

--- a/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
+++ b/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
@@ -356,9 +356,8 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
     @Override
     public void waitComplete() {
         //TODO Review the side effect with multiple motors
-        while(this.isMoving()){
-            // do stuff or do nothing
-            // possibly sleep for some short interval to not block
+        while(this.isMoving()) {
+            Delay.msDelay(1);
         }
     }
 

--- a/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
+++ b/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
@@ -165,18 +165,18 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
      * and the position of the motors will not be maintained.
      */
     @Override
-    public void flt(boolean b) {
-        this.flt();
+    public void flt(boolean immediateReturn) {
+        doStop(COAST, immediateReturn);
     }
 
     @Override
     public void flt() {
-        this.setStringAttribute(STOP_COMMAND, COAST);
+        flt(false);
     }
 
     @Override
     public void coast() {
-        this.setStringAttribute(STOP_COMMAND, COAST);
+        doStop(COAST, false);
     }
 
     /**
@@ -186,7 +186,7 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
      * the motor to stop more quickly than coasting.
      */
     public void brake() {
-        this.setStringAttribute(STOP_COMMAND, BRAKE);
+        doStop(BRAKE, false);
     }
 
     /**
@@ -195,7 +195,7 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
      */
     @Override
     public void hold() {
-        this.setStringAttribute(STOP_COMMAND, HOLD);
+        doStop(HOLD, false);
     }
 
     /**
@@ -206,17 +206,14 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
      * Cancels any rotate() orders in progress
      */
     public void stop() {
-		this.setStringAttribute(COMMAND, STOP);
-
-        for (RegulatedMotorListener listener : listenerList) {
-            listener.rotationStopped(this, this.getTachoCount(), this.isStalled(), System.currentTimeMillis());
-        }
+        stop(false);
     }
 
     @Override
-    public void stop(boolean b) {
-        this.setStringAttribute(COMMAND, STOP);
+    public void stop(boolean immediateReturn) {
+        doStop(HOLD, immediateReturn);
     }
+
 
     /**
      * Backend for all stop moves. This sets the stop action type and then triggers the stop action.

--- a/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
+++ b/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
@@ -219,6 +219,24 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
     }
 
     /**
+     * Backend for all stop moves. This sets the stop action type and then triggers the stop action.
+     * @param mode One of BRAKE, COAST and HOLD string constants.
+     * @param immediateReturn Whether the function should busy-wait until the motor stops reporting the 'running' state.
+     */
+    private void doStop(String mode, boolean immediateReturn) {
+        this.setStringAttribute(STOP_COMMAND, mode);
+        this.setStringAttribute(COMMAND, STOP);
+
+        if (!immediateReturn) {
+            waitComplete();
+        }
+
+        for (RegulatedMotorListener listener : listenerList) {
+            listener.rotationStopped(this, this.getTachoCount(), this.isStalled(), System.currentTimeMillis());
+        }
+    }
+
+    /**
      * This method returns <b>true </b> if the motors is attempting to rotate.
      * The return value may not correspond to the actual motors movement.<br>
      * For example,  If the motors is stalled, isMoving()  will return <b> true. </b><br>

--- a/src/test/java/ev3dev/actuators/lego/motors/EV3LargeRegulatedMotorTest.java
+++ b/src/test/java/ev3dev/actuators/lego/motors/EV3LargeRegulatedMotorTest.java
@@ -48,6 +48,8 @@ public class EV3LargeRegulatedMotorTest {
 
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
 
+        FakeEV3LargeRegulatedMotor.updateState("\n");
+
         motor.flt();
         motor.flt(true);
 
@@ -65,6 +67,7 @@ public class EV3LargeRegulatedMotorTest {
 
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
         motor.forward();
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
     }
 
@@ -77,6 +80,7 @@ public class EV3LargeRegulatedMotorTest {
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
         motor.suspendRegulation();
         motor.forward();
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
     }
 
@@ -88,6 +92,7 @@ public class EV3LargeRegulatedMotorTest {
 
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
         motor.backward();
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
     }
 
@@ -100,6 +105,7 @@ public class EV3LargeRegulatedMotorTest {
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
         motor.suspendRegulation();
         motor.backward();
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
     }
 
@@ -134,6 +140,7 @@ public class EV3LargeRegulatedMotorTest {
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
         motor.forward();
         motor.isMoving();
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
 
     }
@@ -148,6 +155,7 @@ public class EV3LargeRegulatedMotorTest {
         motor.forward();
         motor.isMoving();
         motor.isStalled();
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
     }
 
@@ -159,11 +167,12 @@ public class EV3LargeRegulatedMotorTest {
 
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
 
-        FakeEV3LargeRegulatedMotor.updateState(" ");
+        FakeEV3LargeRegulatedMotor.updateState("\n");
 
         motor.rotate(90);
         motor.rotate(90, true);
         motor.rotateTo(90);
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
         motor.stop(true);
     }
@@ -177,7 +186,7 @@ public class EV3LargeRegulatedMotorTest {
 
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
 
-        FakeEV3LargeRegulatedMotor.updateState(" ");
+        FakeEV3LargeRegulatedMotor.updateState("\n");
 
         motor.setSpeed(100);
         motor.getSpeed();
@@ -206,11 +215,13 @@ public class EV3LargeRegulatedMotorTest {
             }
         });
 
-        FakeEV3LargeRegulatedMotor.updateState(" ");
+        FakeEV3LargeRegulatedMotor.updateState("\n");
 
         motor.rotate(90);
         motor.rotateTo(90);
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
+        FakeEV3LargeRegulatedMotor.updateState("running\n");
         motor.backward();
         motor.forward();
         motor.removeListener();
@@ -224,10 +235,11 @@ public class EV3LargeRegulatedMotorTest {
 
         EV3LargeRegulatedMotor motor = new EV3LargeRegulatedMotor(MotorPort.A);
 
-        FakeEV3LargeRegulatedMotor.updateState(" ");
+        FakeEV3LargeRegulatedMotor.updateState("\n");
 
         motor.rotate(90,true);
         motor.waitComplete();
+        FakeEV3LargeRegulatedMotor.updateState("\n");
         motor.stop();
     }
 

--- a/src/test/java/fake_ev3dev/ev3dev/actuators/lego/motors/FakeEV3LargeRegulatedMotor.java
+++ b/src/test/java/fake_ev3dev/ev3dev/actuators/lego/motors/FakeEV3LargeRegulatedMotor.java
@@ -54,6 +54,13 @@ public class FakeEV3LargeRegulatedMotor extends FakeLegoRegulatedMotor {
                         MOTOR1 + "/" +
                         MOTOR_DUTY_CYCLE_SP);
         createFile(duty_cycle_sp);
+
+        Path stop_action = Paths.get(
+                EV3DEV_FAKE_SYSTEM_PATH + "/" +
+                        LEGO_TACHO_PATH + "/" +
+                        MOTOR1 + "/" +
+                        MOTOR_STOP_ACTION);
+        createFile(stop_action);
     }
 
     public static void updateState(String newState) throws IOException {


### PR DESCRIPTION
Previously only the stop mode was configured in some functions. This however did not trigger the stop action itself.
This commit adds a stop action execution to flt(), coast(), brake(), hold() and stop().
Also, the immediateReturn argument is supported. There is also a change against the leJOS default - the non-parameterized stop() and flt() calls are non-blocking now. This is documented in the leJOS ADR.

Issue: fixes #665