### PR TITLE
Increase delay in BaseRegulatedMotor to 1000+1000ms

### DIFF
--- a/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
+++ b/src/main/java/ev3dev/actuators/lego/motors/BaseRegulatedMotor.java
@@ -88,10 +88,10 @@ public abstract class BaseRegulatedMotor extends EV3DevMotorDevice implements Re
         if(log.isDebugEnabled())
             log.debug("Setting port in mode: {}", TACHO_MOTOR);
         this.setStringAttribute(MODE, TACHO_MOTOR);
-        Delay.msDelay(500);
+        Delay.msDelay(1000);
         this.detect(TACHO_MOTOR, port);
         //TODO Review to implement asynchronous solution
-        Delay.msDelay(700);
+        Delay.msDelay(1000);
         this.setStringAttribute(COMMAND, RESET);
         if(log.isDebugEnabled())
             log.debug("Motor ready to use on Port: {}",motorPort.getName());


### PR DESCRIPTION
This increases the detection delay from 500+700 ms to 1000+1000 ms.

Before the test, it seems that having the ports in the default mode increases the likelihood of the problem occuring. The ports can be put to it on EV3 this way:
```sh
echo auto | sudo tee /sys/class/lego-port/*/mode
```

Reproducer:
```java
package issues;

import ev3dev.actuators.lego.motors.EV3LargeRegulatedMotor;
import ev3dev.actuators.lego.motors.EV3MediumRegulatedMotor;
import lejos.hardware.port.MotorPort;

public class Issue669 {
    public static void main(String[] args) {
        for (int i = 0; i < 10; i++) {
            EV3MediumRegulatedMotor m = new EV3MediumRegulatedMotor(MotorPort.A);
            m.stop();
        }
    }
}
```