### PR TITLE
Deprecated non used LCD Methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id "com.github.johnrengelman.shadow" version "4.0.3"
 }
 
-version = '2.5.5'
+version = '2.6.0-SNAPSHOT'
 
 repositories {
     jcenter()
@@ -94,6 +94,9 @@ test {
 test.finalizedBy jacocoTestReport
 test.finalizedBy jacocoTestCoverageVerification
 
+apply from: './gradle/config.gradle'
+apply from: './gradle/docker.gradle'
+
 //Jar
 jar {
     baseName = "${rootProject.name}"
@@ -114,8 +117,6 @@ task fatJar {
 fatJar.dependsOn shadowJar
 
 
-apply from: './gradle/config.gradle'
-apply from: './gradle/docker.gradle'
 
 /* global settings */
 configure(allprojects) { project ->

--- a/src/main/java/ev3dev/actuators/LCDJessie.java
+++ b/src/main/java/ev3dev/actuators/LCDJessie.java
@@ -234,16 +234,19 @@ public class LCDJessie extends EV3DevDevice implements GraphicsLCD {
         log.debug("Feature not implemented");
     }
 
+    @Deprecated
     @Override
     public void drawRegionRop(Image image, int i, int i1, int i2, int i3, int i4, int i5, int i6, int i7) {
         log.debug("Feature not implemented");
     }
 
+    @Deprecated
     @Override
     public void drawRegionRop(Image image, int i, int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8) {
         log.debug("Feature not implemented");
     }
 
+    @Deprecated
     @Override
     public void drawRegion(Image image, int i, int i1, int i2, int i3, int i4, int i5, int i6, int i7) {
         log.debug("Feature not implemented");

--- a/src/main/java/ev3dev/actuators/LCDStretch.java
+++ b/src/main/java/ev3dev/actuators/LCDStretch.java
@@ -216,11 +216,13 @@ public class LCDStretch extends EV3DevDevice implements GraphicsLCD {
         g2d.setStroke(stroke);
     }
 
+    @Deprecated
     @Override
     public void drawRegionRop(Image src, int sx, int sy, int w, int h, int x, int y, int anchor, int rop) {
         drawRegionRop(src, sx, sy, w, h, x, y, TRANS_NONE, anchor, rop);
     }
 
+    @Deprecated
     @Override
     public void drawRegionRop(Image src, int sx, int sy, int w, int h, int transform, int x, int y, int anchor, int rop) {
         x = adjustX(x, w, anchor);
@@ -278,6 +280,7 @@ public class LCDStretch extends EV3DevDevice implements GraphicsLCD {
         g2d.drawImage(dstI, 0, 0, null);
     }
 
+    @Deprecated
     @Override
     public void drawRegion(Image src,
                            int sx, int sy,

--- a/src/main/java/ev3dev/hardware/EV3DevDistros.java
+++ b/src/main/java/ev3dev/hardware/EV3DevDistros.java
@@ -36,7 +36,7 @@ public class EV3DevDistros {
 
     private EV3DevDistros() {
 
-        LOGGER.info("Providing an EV3DevDistros instance");
+        LOGGER.debug("Providing an EV3DevDistros instance");
 
         final String osResult = Shell.execute(DEBIAN_DISTRO_DETECTION_QUERY);
         if (osResult.contains(DEBIAN_DISTRO_DETECTION_JESSIE)) {

--- a/src/main/java/ev3dev/hardware/EV3DevPlatforms.java
+++ b/src/main/java/ev3dev/hardware/EV3DevPlatforms.java
@@ -36,7 +36,7 @@ public class EV3DevPlatforms {
 
     private EV3DevPlatforms() {
 
-        LOGGER.info("Providing a EV3DevPlatforms instance");
+        LOGGER.debug("Providing a EV3DevPlatforms instance");
 
         // load properties from jar
         final EV3DevPropertyLoader ev3DevPropertyLoader = new EV3DevPropertyLoader();


### PR DESCRIPTION
Deprecating non used methods. 
The rest is Ok.

```
Upgrading library version
Moving gradle config files in order to be used in an effective way
Deprecating some non used methods from the original LeJOS implementation
Decreasing some Log level messages in some classes
```