### PR TITLE
fix(sensors): do not truncate negative values for gyro

### DIFF
--- a/src/main/java/ev3dev/sensors/ev3/EV3GyroSensor.java
+++ b/src/main/java/ev3dev/sensors/ev3/EV3GyroSensor.java
@@ -45,9 +45,12 @@ public class EV3GyroSensor extends BaseSensor {
 		super(portName, LEGO_UART_SENSOR, LEGO_EV3_GYRO);
 
 		setModes(new SensorMode[] {
-				new GenericMode(this.PATH_DEVICE, 1, "Rate"),
-				new GenericMode(this.PATH_DEVICE, 1, "Angle"),
-				new GenericMode(this.PATH_DEVICE, 2, "Angle and Rate")
+				new GenericMode(this.PATH_DEVICE, 1, "Rate",
+						-Float.MAX_VALUE, +Float.MAX_VALUE, 1.0f),
+				new GenericMode(this.PATH_DEVICE, 1, "Angle",
+						-Float.MAX_VALUE, +Float.MAX_VALUE, 1.0f),
+				new GenericMode(this.PATH_DEVICE, 2, "Angle and Rate",
+						-Float.MAX_VALUE, +Float.MAX_VALUE, 1.0f),
 		});
 	}
 

--- a/src/test/java/ev3dev/sensors/ev3/EV3GyroSensorTest.java
+++ b/src/test/java/ev3dev/sensors/ev3/EV3GyroSensorTest.java
@@ -147,4 +147,27 @@ public class EV3GyroSensorTest {
         assertThat(fakeEV3GyroSensor.getCurrentMode(), is("GYRO-G&A"));
     }
 
+
+    @Test
+    public void negativeAngleTest() throws Exception {
+        // Tests fix for https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/693
+        // Before: negative values get truncated to zero
+        // After:  negative values get passed through
+
+        final FakeBattery fakeBattery = new FakeBattery(EV3DevPlatform.EV3BRICK);
+        final FakeEV3GyroSensor fakeEV3GyroSensor = new FakeEV3GyroSensor(EV3DevPlatform.EV3BRICK);
+
+        EV3GyroSensor gyroSensor = new EV3GyroSensor(SensorPort.S1);
+        final SampleProvider sp = gyroSensor.getAngleMode();
+
+        final float[] sample = new float[sp.sampleSize()];
+        final int realAngle = -180;
+
+        fakeEV3GyroSensor.setValue(0, String.valueOf(realAngle));
+        sp.fetchSample(sample, 0);
+
+        int measuredAngle = Math.round(sample[0]);
+
+        assertThat(measuredAngle, is(realAngle));
+    }
 }

--- a/src/test/java/fake_ev3dev/BaseElement.java
+++ b/src/test/java/fake_ev3dev/BaseElement.java
@@ -83,9 +83,13 @@ public abstract class BaseElement {
 
     protected void populateValues(final List<Integer> values) throws IOException {
         for (int i = 0; i < values.size(); i++) {
-            Path value = Paths.get(SENSOR1_BASE, "value" + i);
-            createFile(value, String.valueOf(values.get(i)));
+            setValue(i, String.valueOf(values.get(i)));
         }
+    }
+
+    public void setValue(final int index, final String value) throws IOException {
+        Path path = Paths.get(SENSOR1_BASE, "value" + index);
+        createFile(path, value);
     }
 
 }


### PR DESCRIPTION
Previously, negative values from sensors were truncated to zero. This happened because Float.MIN_VALUE in Java is the smallest _positive_ value that a float can have. It is therefore necessary to use -Float.MAX_VALUE as a lower bound to disable limiting.

Reproducer can be created from the provided unit test. I've checked that without the fix, the provided unit test fails and succeeds when the change is applied.

Fixes: https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/693