### PR TITLE
Use `api` for marking transitive compile+runtime dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@
 plugins {
     id 'io.franzbecker.gradle-lombok' version '1.14'
     id 'java'
+    id 'java-library'
     id 'eclipse'
     id 'idea'
     id "jacoco"
@@ -34,9 +35,9 @@ dependencies {
     compileOnly("org.projectlombok:lombok:1.16.20")
     testCompileOnly("org.projectlombok:lombok:1.16.20")
 
-    compile("org.slf4j:slf4j-api:1.7.25")
-    compile("com.github.ev3dev-lang-java:lejos-commons:0.7.3")
-    compile("net.java.dev.jna:jna:4.5.2")
+    api("org.slf4j:slf4j-api:1.7.25")
+    api("com.github.ev3dev-lang-java:lejos-commons:0.7.3")
+    api("net.java.dev.jna:jna:4.5.2")
 
     testImplementation("ch.qos.logback:logback-classic:1.2.3")
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id "com.github.johnrengelman.shadow" version "4.0.3"
 }
 
-version = '2.6.1-SNAPSHOT'
+version = '2.6.2-SNAPSHOT'
 
 repositories {
     jcenter()


### PR DESCRIPTION
We have previously switched from `compile` to `implementation`.
This had an unexpected consequence, however - `implementation`
does not make dependencies transitive. The quick fix is to
switch back to `compile`, which is marked as deprecated, however.

As an alternative, there exists an `api` label in the `java-library`
Gradle plugin. According to https://stackoverflow.com/a/53726023 ,
this plugin extends the Java plugin and provides functionality
for Java libraries, which is exactly what is needed.