### PR TITLE
Channel reset

### DIFF
--- a/src/main/java/ev3dev/utils/DataChannelRereader.java
+++ b/src/main/java/ev3dev/utils/DataChannelRereader.java
@@ -1,0 +1,71 @@
+package ev3dev.utils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Reader of streams that can reread the same channel for structured data of
+ * known length. The focus of this class is on performance.
+ *
+ * @author David Walend
+ */
+public class DataChannelRereader implements Closeable {
+
+    private final Path path;
+    private final ByteBuffer byteBuffer;
+    private final FileChannel channel;
+
+    /**
+     * Create a DataChannelRereader for path with a bufferLength byte buffer
+     *
+     * @param path path to the file to reread
+     * @param bufferLength length of the buffer to hold the structure
+     * @throws IOException when things go wrong
+     */
+    public DataChannelRereader(Path path, int bufferLength) throws IOException {
+        this.path = path;
+        this.byteBuffer = ByteBuffer.allocate(bufferLength);
+        this.channel = FileChannel.open(path);
+    }
+
+    /**
+     * Create a DataChannelRereader for pathString with the default 32-byte buffer.
+     *
+     * @param pathString Path to the file to reread
+     * @throws IOException when things go wrong
+     */
+    public DataChannelRereader(String pathString) throws IOException {
+        this(Paths.get(pathString),32);
+    }
+
+    /**
+     * @return a string made from the bytes in the file;
+     */
+    public String readString() {
+        try {
+            int n;
+            do {
+                byteBuffer.clear();
+                channel.position(0);
+                n = channel.read(byteBuffer);
+                if (n == -1) throw new IOException("Premature end of file ");
+            } while (n <= 0);
+
+            byte[] bytes = byteBuffer.array();
+            if (bytes[n-1] == '\n') return new String(bytes, 0, n-1, StandardCharsets.UTF_8);
+            else return new String(bytes, 0, n, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Problem reading path: "+path, e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/src/main/java/ev3dev/utils/Sysfs2.java
+++ b/src/main/java/ev3dev/utils/Sysfs2.java
@@ -91,8 +91,8 @@ public class Sysfs2 {
         if (log.isTraceEnabled()) {
             log.trace("cat " + filePath);
         }
-        setPathString(filePath);
-        String result = readStringCustomChannel();
+        final Path path = Paths.get(filePath) ;
+        String result = readStringCustomChannel(path);
         if (log.isTraceEnabled()) {
             log.trace("value: {}", result);
         }
@@ -166,6 +166,7 @@ public class Sysfs2 {
     //}
 
     //Static Setter to test the idea from @dwalend
+/*
     public static void setPathString(String pathString) {
         Sysfs2.pathString = pathString;
     }
@@ -174,15 +175,17 @@ public class Sysfs2 {
 
     private static final byte[] buffer = new byte[8];
     static final Path staticPath = Paths.get(pathString);
-    public static String readStringCustomChannel() {
+*/
+    public static String readStringCustomChannel(Path path) {
+        final byte[] buffer = new byte[8];
         try {
-            try (InputStream in = customInputStream(staticPath)) {
+            try (InputStream in = customInputStream(path)) {
                 int n = in.read(buffer);
-                //todo throw IOException for n = -1
+                if(n == -1) throw new IOException("Premature end of file "+path);
                 return new String(buffer, StandardCharsets.US_ASCII);
             }
         } catch (IOException e) {
-            throw new RuntimeException("Problem reading path: " + pathString, e);
+            throw new RuntimeException("Problem reading path: " + path, e);
         }
     }
 

--- a/src/main/java/ev3dev/utils/Sysfs2.java
+++ b/src/main/java/ev3dev/utils/Sysfs2.java
@@ -1,6 +1,5 @@
 package ev3dev.utils;
 
-import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/ev3dev/utils/Sysfs2.java
+++ b/src/main/java/ev3dev/utils/Sysfs2.java
@@ -140,7 +140,7 @@ public class Sysfs2 {
     //Skipping much of the boilerplate between InputStream and Channels. 12 ms, but 6 ms with the static path!
 
     static String readStringCustomChannel(Path path) {
-        final byte[] buffer = new byte[16];
+        final byte[] buffer = new byte[32];
         try {
             try (InputStream in = customInputStream(path)) {
                 int n = in.read(buffer);


### PR DESCRIPTION
I've created DataChannelRereader - a Closable wrapped around a FileChannel that lets us reread the same fixed-length structure very efficiently.

I've used it (without reusing it) in Sysfs2, to read Strings as a first step. From here I can expand outward into the device and mode APIs to reuse it for specific optimizations, and add to DataChannelRereader to support binary data, as incremental steps.