### PR TITLE
Generic mode rereader

### DIFF
--- a/src/main/java/ev3dev/sensors/GenericMode.java
+++ b/src/main/java/ev3dev/sensors/GenericMode.java
@@ -101,7 +101,7 @@ public class GenericMode implements SensorMode, Closeable {
             // apply correction
             reading *= correctFactor;
             if (reading < correctMin) {
-                reading = Float.NEGATIVE_INFINITY;
+                reading = 0;
             } else if (reading >= correctMax) {
                 reading = Float.POSITIVE_INFINITY;
             }

--- a/src/main/java/ev3dev/sensors/GenericMode.java
+++ b/src/main/java/ev3dev/sensors/GenericMode.java
@@ -1,9 +1,12 @@
 package ev3dev.sensors;
 
-import ev3dev.utils.Sysfs;
+import ev3dev.utils.DataChannelRereader;
 import lejos.hardware.sensor.SensorMode;
 
+import java.io.Closeable;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * Generic ev3dev sensor handler.
@@ -12,15 +15,17 @@ import java.io.File;
  * are valid only when the sensor itself is in the correct mode.
  * Otherwise, wrong data will be returned.</p>
  */
-public class GenericMode implements SensorMode {
 
-    protected final File pathDevice;
+public class GenericMode implements SensorMode, Closeable {
+
     private final int sampleSize;
     private final String modeName;
 
     private final float correctMin;
     private final float correctMax;
     private final float correctFactor;
+
+    private final DataChannelRereader[] rereaders;
 
     /**
      * Create new generic sensor handler.
@@ -29,11 +34,11 @@ public class GenericMode implements SensorMode {
      * @param modeName Human-readable sensor mode name.
      */
     public GenericMode(
-            final File pathDevice,
-            final int sampleSize,
-            final String modeName) {
+        final File pathDevice,
+        final int sampleSize,
+        final String modeName) {
         this(pathDevice, sampleSize, modeName,
-                Float.MIN_VALUE, Float.MAX_VALUE, 1.0f);
+            Float.MIN_VALUE, Float.MAX_VALUE, 1.0f);
     }
 
     /**
@@ -42,23 +47,27 @@ public class GenericMode implements SensorMode {
      * @param pathDevice Reference to the object responsible for mode setting and value reading.
      * @param sampleSize Number of returned samples.
      * @param modeName Human-readable sensor mode name.
-     * @param correctMin Minimum value measured by the sensor. If the reading is lower, zero is returned.
+     * @param correctMin Minimum value measured by the sensor. If the reading is lower, negative infinity is returned
      * @param correctMax Maximum value measured by the sensor. If the reading is higher, positive infinity is returned.
      * @param correctFactor Scaling factor applied to the sensor reading.
      */
     public GenericMode(
-            final File pathDevice,
-            final int sampleSize,
-            final String modeName,
-            final float correctMin,
-            final float correctMax,
-            final float correctFactor) {
-        this.pathDevice = pathDevice;
+        final File pathDevice,
+        final int sampleSize,
+        final String modeName,
+        final float correctMin,
+        final float correctMax,
+        final float correctFactor) {
         this.sampleSize = sampleSize;
         this.modeName = modeName;
         this.correctMin = correctMin;
         this.correctMax = correctMax;
         this.correctFactor = correctFactor;
+
+        this.rereaders = new DataChannelRereader[sampleSize];
+        for (int n = 0; n < sampleSize; n++) {
+            rereaders[n] = new DataChannelRereader(Path.of(pathDevice.toString(),"value" + n),32);
+        }
     }
 
     @Override
@@ -70,7 +79,6 @@ public class GenericMode implements SensorMode {
     public int sampleSize() {
         return sampleSize;
     }
-
 
     /**
      * Fetches a sample from the sensor.
@@ -88,18 +96,25 @@ public class GenericMode implements SensorMode {
         // for all values
         for (int n = 0; n < sampleSize; n++) {
             // read
-            float reading = Sysfs.readFloat(this.pathDevice + "/" + "value" + n);
+            float reading = Float.parseFloat(rereaders[n].readString());
 
             // apply correction
             reading *= correctFactor;
             if (reading < correctMin) {
-                reading = 0;
+                reading = Float.NEGATIVE_INFINITY;
             } else if (reading >= correctMax) {
                 reading = Float.POSITIVE_INFINITY;
             }
 
             // store
             sample[offset + n] = reading;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (DataChannelRereader rereader: rereaders) {
+            rereader.close();
         }
     }
 }

--- a/src/main/java/ev3dev/sensors/nxt/NXTTemperatureSensor.java
+++ b/src/main/java/ev3dev/sensors/nxt/NXTTemperatureSensor.java
@@ -51,6 +51,7 @@ public class NXTTemperatureSensor extends BaseSensor {
         private final float correctMin;
         private final float correctMax;
         private final float correctFactor;
+        private final File pathDevice;
 
         public InternalMode(File pathDevice, int sampleSize, String modeName,
                             float correctMin, float correctMax, float correctFactor) {
@@ -59,6 +60,7 @@ public class NXTTemperatureSensor extends BaseSensor {
             this.correctMin = correctMin;
             this.correctMax = correctMax;
             this.correctFactor = correctFactor;
+            this.pathDevice = pathDevice;
         }
 
         @Override


### PR DESCRIPTION
Here's what GenericMode looks like with DataChannelRereaders. 

Unfortunately changing GenericMode touches half a dozen different sensors. Four of the tests for The EV3 touch sensor break. Also, NXTTemperatureSensor's internal mode extends it. This change is high-touch, goes much further than EV3GyroSensor.